### PR TITLE
fixing annotated optional argument example

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -243,7 +243,7 @@ Annotated optional argument
 val succ : ?x:int -> unit -> int option
 ```
 ```ocaml {.ml}
-let succ ?(x : int) () = x + 1
+let succ ?(x : int option) () = Option.map ~f:(fun n -> n + 1) x
 ```
 
 Annotated optional argument with a default value


### PR DESCRIPTION
I believe there was a small mistake in the annotated optional argument. It was written as if the optional argument has type int, and None is automatically returned if it isn't provided. I changed it to treat the argument as an int option, and it now compiles normally.