### PR TITLE
universal, not existential

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -52,7 +52,7 @@ assert (!sum = 6)
 Note that the range is inclusive on both ends.
 {.caption}
 
-Existentially typed record field
+Universally quantified record fields.
 {.label}
 
 ```ocaml {.mli}


### PR DESCRIPTION
These record fields are universally, not existentially quantified. Sometimes these are called "polymorphic record fields", but I think that's confusing. I chose this name from the manual:

https://v2.ocaml.org/manual/polymorphism.html#s%3Ahigher-rank-poly

I really should cover these in RWO.