### PR TITLE
adding example for explicit passing of an optional argument

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -250,6 +250,15 @@ val succ : ?x:int -> unit -> int
 let succ ?x:(y : int = 0) () = y + 1
 ```
 
+Explicit passing of an optional argument
+{.label}
+```ocaml {.ml}
+let succ ?(x : int = 0) () = x + 1
+let one = succ ?x:None ()
+let two = succ ?x:(Some one) ()
+let negative_succ ?(x : int option) () = -(succ ?x ())
+```
+
 Locally abstract type (monomorphic)
 {.label}
 


### PR DESCRIPTION
Due to my debilitating inability to use Git correctly, I was unable to figure out how to fix the fact that I was trying to merge, so I just created a new fork and PR; hope that's okay :)

Beyond that, I added the explicit invocation you suggested. I did keep in the `negative_succ` example as well b/c it seemed useful to me, but if you feel strongly against I can remove it.